### PR TITLE
docs(swagger): configuración de Swagger UI y rutas públicas

### DIFF
--- a/src/main/java/pe/edu/upc/trabajoparcial/security/SecurityConfiguration.java
+++ b/src/main/java/pe/edu/upc/trabajoparcial/security/SecurityConfiguration.java
@@ -19,11 +19,14 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 public class SecurityConfiguration {
 
+    // ✅ Swagger y rutas públicas permitidas sin autenticación
     private static final String[] AUTH_WHITELIST = {
             "/v2/api-docs/**",
             "/v3/api-docs/**",
             "/swagger-resources/**",
+            "/swagger-ui/**",
             "/swagger-ui.html",
+            "/webjars/**",
             "/api/usuarios/users/login",
             "/api/usuarios/users"
     };
@@ -54,7 +57,6 @@ public class SecurityConfiguration {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-
         http
                 .csrf(csrf -> csrf.disable())
                 .cors(Customizer.withDefaults())
@@ -62,10 +64,7 @@ public class SecurityConfiguration {
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AUTH_WHITELIST).permitAll()
-
-                        // ✅ Permitir acceso a /api/protegido/** a cualquier usuario autenticado
                         .requestMatchers(HttpMethod.GET, "/api/protegido/**").authenticated()
-
                         .requestMatchers(HttpMethod.GET, "/socrates/faculties/**").hasAnyAuthority("ROLE_USER", "ROLE_ASSIST", "ROLE_ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/socrates/faculties/**").hasAnyAuthority("ROLE_ASSIST", "ROLE_ADMIN")
                         .requestMatchers(HttpMethod.POST, "/socrates/faculties/**").hasAnyAuthority("ROLE_ASSIST", "ROLE_ADMIN")
@@ -77,4 +76,5 @@ public class SecurityConfiguration {
         return http.build();
     }
 }
+
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,4 +13,6 @@ spring.jpa.hibernate.ddl-auto=update
 
 # PUERTO DE LA APLICACIÓN
 server.port=8082
-
+# ACTIVAR Swagger OpenAPI
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true


### PR DESCRIPTION
Este pull request implementa la integración de Swagger UI en el proyecto, permitiendo la documentación automática de los endpoints RESTful.

Cambios realizados:

Se añadió la dependencia springdoc-openapi-starter-webmvc-ui en pom.xml

Se configuraron las rutas públicas para /swagger-ui/** y /v3/api-docs/** en SecurityConfiguration.java

Se activó Swagger en application.properties

Con esta configuración, la documentación está accesible en:
http://localhost:8082/swagger-ui/index.html